### PR TITLE
Add ability to pass command options to transfer

### DIFF
--- a/transfer/rsync/client.go
+++ b/transfer/rsync/client.go
@@ -237,11 +237,20 @@ func NewClient(ctx context.Context, c ctrlclient.Client,
 // TODO: add retries
 func (tc *client) reconcilePod(ctx context.Context, c ctrlclient.Client, ns string) error {
 	var errs []error
-	rsyncOptions, err := rsyncCommandWithDefaultFlags()
+
+	rsyncOptions, err := rsyncDefaultOptions()
 	if err != nil {
-		tc.logger.Error(err, "unable to get default flags for rsync command")
+		tc.logger.Error(err, "unable to get default options for rsync command")
 		return err
 	}
+	if tc.options.CommandOptions != nil {
+		rsyncOptions, err = tc.options.CommandOptions.Options()
+		if err != nil {
+			tc.logger.Error(err, "unable to apply custom options for rsync command")
+			return err
+		}
+	}
+
 	for _, pvc := range tc.pvcList.InNamespace(ns).PVCs() {
 		// create Rsync command for PVC
 		rsyncContainerCommand := tc.getCommand(rsyncOptions, pvc)

--- a/transfer/rsync/command_options.go
+++ b/transfer/rsync/command_options.go
@@ -2,9 +2,11 @@ package rsync
 
 import (
 	"fmt"
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"regexp"
 	"strings"
+
+	"github.com/backube/pvc-transfer/transfer"
+	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 const (
@@ -53,8 +55,8 @@ type CommandOptions struct {
 	Extras        []string
 }
 
-// AsRsyncCommandOptions returns validated rsync options and validation errors as two lists
-func (c *CommandOptions) AsRsyncCommandOptions() ([]string, error) {
+// Options returns validated rsync options and validation errors as two lists
+func (c *CommandOptions) Options() ([]string, error) {
 	var errs []error
 	opts := []string{}
 	if c.Recursive {
@@ -119,6 +121,13 @@ func (c *CommandOptions) AsRsyncCommandOptions() ([]string, error) {
 	return opts, errorsutil.NewAggregate(errs)
 }
 
+func NewDefaultOptionsFrom(opts ...Applier) transfer.CommandOptions {
+	c := &CommandOptions{}
+	c.Apply(rsyncCommandDefaultOptions()...)
+	c.Apply(opts...)
+	return c
+}
+
 func filterRsyncInfoOptions(options []string) (validatedOptions []string, err error) {
 	var errs []error
 	r := regexp.MustCompile(`^[A-Z]+\d?$`)
@@ -162,14 +171,14 @@ func (c *CommandOptions) Apply(opts ...Applier) error {
 	return errorsutil.NewAggregate(errs)
 }
 
-func rsyncCommandWithDefaultFlags() ([]string, error) {
+func rsyncDefaultOptions() ([]string, error) {
 	c := CommandOptions{}
 	defaultOptions := rsyncCommandDefaultOptions()
 	err := c.Apply(defaultOptions...)
 	if err != nil {
 		return nil, err
 	}
-	return c.AsRsyncCommandOptions()
+	return c.Options()
 }
 
 type ArchiveFiles bool

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -68,6 +68,13 @@ type PodOptions struct {
 	// it is good to provision destination transfer pod with same or larger resources than the source
 	// so that the network is not congested.
 	Resources corev1.ResourceRequirements
+	// CommandOptions allow configuring the additional options that are passed to entrypoint commands
+	// of transfer containers.
+	CommandOptions
+}
+
+type CommandOptions interface {
+	Options() ([]string, error)
 }
 
 type Status struct {


### PR DESCRIPTION
**Describe what this PR does**
Introduces a new interface to pass extra options to Pod commands used by different transfers. The extra options are merged into entrypoint commands by transfers. Different transfers may implement options differently finally giving away a []string to merge into pod command.


**Is there anything that requires special attention?**


**Related issues:**

