### PR TITLE
Fix generation of resource names

### DIFF
--- a/endpoint/route/route_test.go
+++ b/endpoint/route/route_test.go
@@ -144,7 +144,7 @@ func TestNew(t *testing.T) {
 			AddToScheme(fakeClient.Scheme())
 			ctx := context.WithValue(context.Background(), "test", tt.name)
 			fakeLogger := logrtesting.TestLogger{t}
-			_, gotError := New(ctx, fakeClient, fakeLogger, tt.namespacedName, tt.eType, tt.labels, tt.ownerReferences)
+			endpoint, gotError := New(ctx, fakeClient, fakeLogger, tt.namespacedName, tt.eType, nil, tt.labels, tt.ownerReferences)
 			route := &routev1.Route{}
 			err := fakeClient.Get(context.Background(), tt.namespacedName, route)
 			if err != nil {
@@ -163,7 +163,7 @@ func TestNew(t *testing.T) {
 			if svc.Spec.Type != corev1.ServiceTypeClusterIP && !reflect.DeepEqual(svc.Spec.Selector, tt.labels) && svc.Spec.Ports[0].Port != TLSTerminationPassthroughPolicyPort {
 				t.Errorf("didnt get the expected service %#v", svc)
 			}
-
+			_, gotError = endpoint.IsHealthy(context.TODO(), fakeClient)
 			if (gotError != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", gotError, tt.wantErr)
 				return

--- a/transfer/rsync/server.go
+++ b/transfer/rsync/server.go
@@ -247,7 +247,8 @@ func NewServerWithStunnelRoute(ctx context.Context, c ctrlclient.Client, logger 
 	e, err := route.New(ctx, c, logger, types.NamespacedName{
 		Namespace: namespace,
 		Name:      hm[namespace],
-	}, route.EndpointTypePassthrough, labels, ownerRefs)
+	}, route.EndpointTypePassthrough, nil,
+		labels, ownerRefs)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/stunnel/client_test.go
+++ b/transport/stunnel/client_test.go
@@ -44,7 +44,7 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-credentials",
+						Name:      "stunnel-credentials-client-foo",
 						Namespace: "bar",
 					},
 					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
@@ -60,7 +60,7 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-credentials",
+						Name:      "stunnel-credentials-client-foo",
 						Namespace: "bar",
 					},
 					Data: map[string][]byte{"tls.crt": []byte(`crt`)},
@@ -76,7 +76,7 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-config",
+						Name:      "stunnel-config-client-foo",
 						Namespace: "bar",
 					},
 					Data: map[string]string{"stunnel.conf": "foreground = yes"},
@@ -92,7 +92,7 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-config",
+						Name:      "stunnel-config-foo-client",
 						Namespace: "bar",
 					},
 					Data: map[string]string{"stunnel.conf": "foreground = no"},
@@ -113,7 +113,7 @@ func TestNewClient(t *testing.T) {
 			cm := &corev1.ConfigMap{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      "foo-client-" + stunnelConfig,
+				Name:      stunnelConfig + "-client-foo",
 			}, cm)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))
@@ -130,7 +130,7 @@ func TestNewClient(t *testing.T) {
 			secret := &corev1.Secret{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      "foo-client-" + stunnelSecret,
+				Name:      stunnelSecret + "-client-foo",
 			}, secret)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))

--- a/transport/stunnel/server.go
+++ b/transport/stunnel/server.go
@@ -127,7 +127,10 @@ func (s *server) Type() transport.Type {
 }
 
 func (s *server) Credentials() types.NamespacedName {
-	return types.NamespacedName{Name: s.prefixedName(stunnelSecret), Namespace: s.NamespacedName().Namespace}
+	return types.NamespacedName{
+		Name:      getResourceName(s.namespacedName, "server", stunnelSecret),
+		Namespace: s.NamespacedName().Namespace,
+	}
 }
 
 func (s *server) Hostname() string {
@@ -177,10 +180,6 @@ func (s *server) reconcileConfig(ctx context.Context, c ctrlclient.Client) error
 	return err
 }
 
-func (s *server) prefixedName(name string) string {
-	return s.namespacedName.Name + "-server-" + name
-}
-
 func (s *server) reconcileSecret(ctx context.Context, c ctrlclient.Client) error {
 	secretValid, err := isSecretValid(ctx, c, s.logger, s.namespacedName, "server")
 	if err != nil {
@@ -219,7 +218,7 @@ func (s *server) serverContainers() []corev1.Container {
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
-					Name:      s.prefixedName(stunnelConfig),
+					Name:      getResourceName(s.namespacedName, "server", stunnelConfig),
 					MountPath: "/etc/stunnel/stunnel.conf",
 					SubPath:   "stunnel.conf",
 				},
@@ -235,11 +234,11 @@ func (s *server) serverContainers() []corev1.Container {
 func (s *server) serverVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
-			Name: s.prefixedName(stunnelConfig),
+			Name: getResourceName(s.namespacedName, "server", stunnelConfig),
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: s.prefixedName(stunnelConfig),
+						Name: getResourceName(s.namespacedName, "server", stunnelConfig),
 					},
 				},
 			},

--- a/transport/stunnel/server_test.go
+++ b/transport/stunnel/server_test.go
@@ -100,7 +100,7 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-server-stunnel-credentials",
+						Name:      "stunnel-credentials-server-foo",
 						Namespace: "bar",
 					},
 					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
@@ -117,7 +117,7 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-server-stunnel-credentials",
+						Name:      "stunnel-credentials-server-foo",
 						Namespace: "bar",
 					},
 					Data: map[string][]byte{"tls.crt": []byte(`crt`)},
@@ -134,7 +134,7 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-server-stunnel-config",
+						Name:      "stunnel-config-server-foo",
 						Namespace: "bar",
 					},
 					Data: map[string]string{"stunnel.conf": "foreground = yes"},
@@ -151,7 +151,7 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-server-stunnel-config",
+						Name:      "stunnel-config-server-foo",
 						Namespace: "bar",
 					},
 					Data: map[string]string{"stunnel.conf": "foreground = no"},
@@ -172,7 +172,7 @@ func TestNewServer(t *testing.T) {
 			cm := &corev1.ConfigMap{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      "foo-server-" + stunnelConfig,
+				Name:      stunnelConfig + "-server-foo",
 			}, cm)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))
@@ -189,7 +189,7 @@ func TestNewServer(t *testing.T) {
 			secret := &corev1.Secret{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      "foo-server-" + stunnelSecret,
+				Name:      stunnelSecret + "-server-foo",
 			}, secret)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))

--- a/transport/stunnel/stunnel.go
+++ b/transport/stunnel/stunnel.go
@@ -36,8 +36,12 @@ func getImage(options *transport.Options) string {
 	}
 }
 
-func getResourceName(obj types.NamespacedName, component, suffix string) string {
-	return fmt.Sprintf("%s-%s-%s", obj.Name, component, suffix)
+func getResourceName(obj types.NamespacedName, component, prefix string) string {
+	resourceName := fmt.Sprintf("%s-%s-%s", prefix, component, obj.Name)
+	if len(resourceName) > 62 {
+		return resourceName[:62]
+	}
+	return resourceName
 }
 
 func isSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger, key types.NamespacedName, component string) (bool, error) {

--- a/transport/stunnel/stunnel_test.go
+++ b/transport/stunnel/stunnel_test.go
@@ -43,7 +43,7 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-stunnel-credentials",
+						Name:      "stunnel-credentials-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -60,7 +60,7 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-stunnel-credentials",
+						Name:      "stunnel-credentials-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -77,7 +77,7 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-stunnel-credentials",
+						Name:      "stunnel-credentials-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -94,7 +94,7 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-foo-stunnel-credentials",
+						Name:      "stunnel-credentials-foo-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -149,7 +149,7 @@ func Test_mrkForCleanup(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-server-stunnel-credentials",
+						Name:      "stunnel-credentials-server-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -157,7 +157,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-credentials",
+						Name:      "stunnel-credentials-client-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -165,7 +165,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-ca-bundle-stunnel-credentials",
+						Name:      "stunnel-credentials-ca-bundle-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -173,7 +173,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-foo-stunnel-config",
+						Name:      "stunnel-config-foo-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -183,22 +183,22 @@ func Test_mrkForCleanup(t *testing.T) {
 			verifyObjects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-foo-" + stunnelConfig,
+						Name: stunnelConfig + "-foo-foo",
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-client-" + stunnelSecret,
+						Name: stunnelSecret + "-client-foo",
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-server-" + stunnelSecret,
+						Name: stunnelSecret + "-server-foo",
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-ca-bundle-" + stunnelSecret,
+						Name: stunnelSecret + "-ca-bundle-foo",
 					},
 				},
 			},
@@ -213,7 +213,7 @@ func Test_mrkForCleanup(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-client-stunnel-credentials",
+						Name:      "stunnel-credentials-client-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -221,7 +221,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-ca-bundle-stunnel-credentials",
+						Name:      "stunnel-credentials-ca-bundle-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -229,7 +229,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo-foo-stunnel-config",
+						Name:      "stunnel-config-foo-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
@@ -239,17 +239,17 @@ func Test_mrkForCleanup(t *testing.T) {
 			verifyObjects: []ctrlclient.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-foo-" + stunnelConfig,
+						Name: stunnelConfig + "-foo-foo",
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-client-" + stunnelSecret,
+						Name: stunnelSecret + "-client-foo",
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "foo-ca-bundle-" + stunnelSecret,
+						Name: stunnelSecret + "-ca-bundle-foo",
 					},
 				},
 			},


### PR DESCRIPTION
**Describe what this PR does**
- Ensures resource names (ConfigMaps, Secrets) created by Transports/Transfers never exceed 63 characters
  - For Routes, long namespace names fail creation of Route object. To circumvent this, this PR introduces `hostname` for Routes too. Callers can pass in a custom hostname in case default Route objects will fail due to namespace length issue. 

-  Removes redundant duplicate method
- Removes IsHealthy() check from reconcile function of Route
  - this is needed because it takes some time for route to  reconcile, and IsHealthy() should be run multiple times with a timeout. It should be called by the caller instead. 

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
