### PR TITLE
minor fixes in rsync

### DIFF
--- a/transfer/rsync/command_options.go
+++ b/transfer/rsync/command_options.go
@@ -210,7 +210,6 @@ func (s StandardProgress) ApplyTo(opts *CommandOptions) error {
 		"COPY2", "DEL2", "REMOVE2", "SKIP2", "FLIST2", "PROGRESS2", "STATS2",
 	}
 	opts.HumanReadable = true
-	opts.LogFile = logFileStdOut
 	return nil
 }
 

--- a/transfer/rsync/server.go
+++ b/transfer/rsync/server.go
@@ -275,12 +275,6 @@ func NewServer(ctx context.Context, c ctrlclient.Client, logger logr.Logger,
 	labels map[string]string,
 	ownerRefs []metav1.OwnerReference,
 	password string, podOptions transfer.PodOptions) (transfer.Server, error) {
-
-	// TODO: add proper validation for podOptions
-	if podOptions.ContainerSecurityContext.RunAsUser != nil && *podOptions.ContainerSecurityContext.RunAsUser != 0 {
-		return nil, fmt.Errorf("running as non-root user is not supported yet")
-	}
-
 	r := &server{
 		username:        "root",
 		password:        password,


### PR DESCRIPTION
**Describe what this PR does**
- Removes error returned when user is not root
- Removes explicit log printing as rsync already writes output to stdout, explicit log file duplicates entries to stdout

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
