### PR TITLE
Enable using a custom rsync image

### DIFF
--- a/transfer/rsync/client.go
+++ b/transfer/rsync/client.go
@@ -248,7 +248,6 @@ func (tc *client) reconcilePod(ctx context.Context, c ctrlclient.Client, ns stri
 		containers := []corev1.Container{
 			{
 				Name:    RsyncContainer,
-				Image:   rsyncImage,
 				Command: rsyncContainerCommand,
 				Env: []corev1.EnvVar{
 					{

--- a/transfer/rsync/rsync.go
+++ b/transfer/rsync/rsync.go
@@ -37,6 +37,11 @@ func applyPodOptions(podSpec *corev1.PodSpec, options transfer.PodOptions) {
 	podSpec.SecurityContext = &options.PodSecurityContext
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
+		if options.Image != "" {
+			c.Image = options.Image
+		} else {
+			c.Image = rsyncImage
+		}
 		c.SecurityContext = &options.ContainerSecurityContext
 		c.Resources = options.Resources
 	}

--- a/transfer/rsync/server.go
+++ b/transfer/rsync/server.go
@@ -495,8 +495,7 @@ done`
 
 	return []corev1.Container{
 		{
-			Name:  RsyncContainer,
-			Image: rsyncImage,
+			Name: RsyncContainer,
 			Command: []string{
 				"/bin/bash",
 				"-c",

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -68,6 +68,8 @@ type PodOptions struct {
 	// it is good to provision destination transfer pod with same or larger resources than the source
 	// so that the network is not congested.
 	Resources corev1.ResourceRequirements
+	// Image allows specifying an alternate image for transfers
+	Image string
 	// CommandOptions allow configuring the additional options that are passed to entrypoint commands
 	// of transfer containers.
 	CommandOptions


### PR DESCRIPTION
**Describe what this PR does**
This PR enables setting a custom image for rsync. We already an option for the stunnel container. With MTRHO / Crane we will likely encounter clusters with restricted networking or in disconnected environments where they will not be able to pull directly from Quay. Furthermore we're likely to encounter a preference for using downstream images from registry.redhat.io at some point in the future.

**Related issues:**
https://github.com/konveyor/crane/issues/116
https://github.com/konveyor/crane/pull/139
