### PR TITLE
Add option to terminate transfer pods on completion

### DIFF
--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -70,6 +70,8 @@ type PodOptions struct {
 	Resources corev1.ResourceRequirements
 	// Image allows specifying an alternate image for transfers
 	Image string
+	// TerminateOnCompletion determines whether transfer containers will terminate after transfer is complete
+	TerminateOnCompletion *bool
 	// CommandOptions allow configuring the additional options that are passed to entrypoint commands
 	// of transfer containers.
 	CommandOptions


### PR DESCRIPTION
**Describe what this PR does**
- This PR modifies existing rsync daemon command, moves the pod termination part of the command behind an option. 

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
