### PR TITLE
Consolidate certificate secrets

### DIFF
--- a/transfer/rsync/rsync.go
+++ b/transfer/rsync/rsync.go
@@ -11,14 +11,11 @@ const (
 
 const (
 	rsyncImage                  = "quay.io/konveyor/rsync-transfer:latest"
-	rsyncConfig                 = "backube-rsync-config"
-	rsyncSecretPrefix           = "backube-rsync"
-	rsyncServiceAccount         = "backube-rsync-sa"
-	rsyncRole                   = "backube-rsync-role"
-	rsyncPassword               = "backube-rsync-password"
-	rsyncPasswordKey            = "RSYNC_PASSWORD"
+	rsyncConfig                 = "rsync-config"
+	rsyncServiceAccount         = "rsync-sa"
+	rsyncRole                   = "rsync-role"
 	rsyncCommunicationMountPath = "/usr/share/rsync"
-	rsyncRoleBinding            = "backube-rsync-rolebinding"
+	rsyncRoleBinding            = "rsync-rolebinding"
 	rsyncdLogDir                = "rsyncd-logs"
 	rsyncdLogDirPath            = "/var/log/rsyncd/"
 )

--- a/transfer/rsync/server.go
+++ b/transfer/rsync/server.go
@@ -67,7 +67,6 @@ hosts allow = *.*.*.*, *
     munge symlinks = no
     list = yes
     read only = false
-    secrets file = /etc/rsync-secret/rsyncd.secrets
 {{ end }}
 `
 )
@@ -136,17 +135,6 @@ func (s *server) MarkForCleanup(ctx context.Context, c ctrlclient.Client, key, v
 		},
 	}
 	err = utils.UpdateWithLabel(ctx, c, cm, key, value)
-	if err != nil {
-		return err
-	}
-	// update secret
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", rsyncSecretPrefix, s.nameSuffix),
-			Namespace: s.namespace,
-		},
-	}
-	err = utils.UpdateWithLabel(ctx, c, secret, key, value)
 	if err != nil {
 		return err
 	}

--- a/transport/stunnel/client_test.go
+++ b/transport/stunnel/client_test.go
@@ -44,10 +44,10 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-client-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
+					Data: map[string][]byte{"client.key": []byte(`key`), "client.crt": []byte(`crt`)},
 				},
 			},
 		},
@@ -60,10 +60,10 @@ func TestNewClient(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-client-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 					},
-					Data: map[string][]byte{"tls.crt": []byte(`crt`)},
+					Data: map[string][]byte{"client.crt": []byte(`crt`)},
 				},
 			},
 		},
@@ -130,18 +130,18 @@ func TestNewClient(t *testing.T) {
 			secret := &corev1.Secret{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      stunnelSecret + "-client-foo",
+				Name:      stunnelSecret + "-certs-foo",
 			}, secret)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))
 			}
 
-			_, ok = secret.Data["tls.key"]
+			_, ok = secret.Data["client.key"]
 			if !ok {
 				t.Error("unable to find tls.key in stunnel secret")
 			}
 
-			_, ok = secret.Data["tls.crt"]
+			_, ok = secret.Data["client.crt"]
 			if !ok {
 				t.Error("unable to find tls.crt in stunnel secret")
 			}

--- a/transport/stunnel/server_test.go
+++ b/transport/stunnel/server_test.go
@@ -100,10 +100,10 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-server-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
+					Data: map[string][]byte{"server.key": []byte(`key`), "server.crt": []byte(`crt`)},
 				},
 			},
 		},
@@ -117,10 +117,10 @@ func TestNewServer(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-server-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 					},
-					Data: map[string][]byte{"tls.crt": []byte(`crt`)},
+					Data: map[string][]byte{"server.crt": []byte(`crt`)},
 				},
 			},
 		},
@@ -189,18 +189,18 @@ func TestNewServer(t *testing.T) {
 			secret := &corev1.Secret{}
 			err = fakeClient.Get(context.Background(), types.NamespacedName{
 				Namespace: "bar",
-				Name:      stunnelSecret + "-server-foo",
+				Name:      stunnelSecret + "-certs-foo",
 			}, secret)
 			if err != nil {
 				panic(fmt.Errorf("%#v should not be getting error from fake client", err))
 			}
 
-			_, ok = secret.Data["tls.key"]
+			_, ok = secret.Data["server.key"]
 			if !ok {
 				t.Error("unable to find tls.key in stunnel secret")
 			}
 
-			_, ok = secret.Data["tls.crt"]
+			_, ok = secret.Data["server.crt"]
 			if !ok {
 				t.Error("unable to find tls.crt in stunnel secret")
 			}

--- a/transport/stunnel/stunnel_test.go
+++ b/transport/stunnel/stunnel_test.go
@@ -43,11 +43,11 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-foo",
+						Name:      "stunnel-creds-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.crt": certificateBundle.ServerCrt.Bytes()},
+					Data: map[string][]byte{"server.crt": certificateBundle.ServerCrt.Bytes()},
 				},
 			},
 		},
@@ -60,11 +60,11 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-foo",
+						Name:      "stunnel-creds-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.key": certificateBundle.ServerKey.Bytes()},
+					Data: map[string][]byte{"server.key": certificateBundle.ServerKey.Bytes()},
 				},
 			},
 		},
@@ -77,11 +77,11 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-foo",
+						Name:      "stunnel-creds-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.key": certificateBundle.ServerKey.Bytes(), "tls.crt": certificateBundle.ServerKey.Bytes()},
+					Data: map[string][]byte{"server.key": certificateBundle.ServerKey.Bytes(), "server.crt": certificateBundle.ServerKey.Bytes()},
 				},
 			},
 		},
@@ -94,11 +94,14 @@ func Test_getExistingCert(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-foo-foo",
+						Name:      "stunnel-creds-foo-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.key": certificateBundle.ServerKey.Bytes(), "tls.crt": certificateBundle.ServerCrt.Bytes(), "ca.crt": certificateBundle.CACrt.Bytes()},
+					Data: map[string][]byte{
+						"server.key": certificateBundle.ServerKey.Bytes(), "server.crt": certificateBundle.ServerCrt.Bytes(),
+						"client.key": certificateBundle.ClientKey.Bytes(), "client.crt": certificateBundle.ClientCrt.Bytes(),
+						"ca.crt": certificateBundle.CACrt.Bytes()},
 				},
 			},
 		},
@@ -149,27 +152,15 @@ func Test_mrkForCleanup(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-server-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-client-foo",
-						Namespace: "bar",
-						Labels:    map[string]string{"test": "me"},
+					Data: map[string][]byte{
+						"server.key": []byte(`key`), "server.crt": []byte(`crt`),
+						"client.key": []byte(`key`), "client.crt": []byte(`crt`),
+						"ca.key": []byte(`key`), "ca.crt": []byte(`crt`),
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-ca-bundle-foo",
-						Namespace: "bar",
-						Labels:    map[string]string{"test": "me"},
-					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -188,17 +179,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: stunnelSecret + "-client-foo",
-					},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: stunnelSecret + "-server-foo",
-					},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: stunnelSecret + "-ca-bundle-foo",
+						Name: stunnelSecret + "-certs-foo",
 					},
 				},
 			},
@@ -213,19 +194,14 @@ func Test_mrkForCleanup(t *testing.T) {
 			objects: []ctrlclient.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-client-foo",
+						Name:      "stunnel-creds-certs-foo",
 						Namespace: "bar",
 						Labels:    map[string]string{"test": "me"},
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "stunnel-credentials-ca-bundle-foo",
-						Namespace: "bar",
-						Labels:    map[string]string{"test": "me"},
+					Data: map[string][]byte{
+						"client.key": []byte(`key`), "client.crt": []byte(`crt`),
+						"ca.key": []byte(`key`), "ca.crt": []byte(`crt`),
 					},
-					Data: map[string][]byte{"tls.key": []byte(`key`), "tls.crt": []byte(`crt`)},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -244,12 +220,7 @@ func Test_mrkForCleanup(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: stunnelSecret + "-client-foo",
-					},
-				},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: stunnelSecret + "-ca-bundle-foo",
+						Name: stunnelSecret + "-certs-foo",
 					},
 				},
 			},


### PR DESCRIPTION
**Describe what this PR does**
- Stunnel Server and Client certs and the CA bundle were stored in three different secrets. This PR consolidates all certificates (server + client + CA) in one secret for users to copy. 
- Also removes some unused constants used for rsync secret that no longer exists
**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
