### PR TITLE
Add ability to use existing PSK secrets

### DIFF
--- a/transfer/rsync/rsync.go
+++ b/transfer/rsync/rsync.go
@@ -43,3 +43,23 @@ func applyPodOptions(podSpec *corev1.PodSpec, options transfer.PodOptions) {
 		c.Resources = options.Resources
 	}
 }
+
+func getTerminationVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "termination",
+			MountPath: "/mnt/termination",
+		},
+	}
+}
+
+func getTerminationVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "termination",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}

--- a/transfer/rsync/server.go
+++ b/transfer/rsync/server.go
@@ -433,6 +433,7 @@ func (s *server) getContainers(volumeMounts []corev1.VolumeMount) []corev1.Conta
 while true; do
 	if [[ -f /mnt/termination/done ]]
 	then
+		sync
 		exit 0; 
 	fi
 	sleep 1;

--- a/transfer/transfer.go
+++ b/transfer/transfer.go
@@ -2,9 +2,7 @@ package transfer
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"math/big"
 
 	"github.com/backube/pvc-transfer/endpoint"
 	"github.com/backube/pvc-transfer/transport"
@@ -176,19 +174,4 @@ func AreFilteredPodsHealthy(ctx context.Context, c client.Client, namespace stri
 	}
 
 	return false, errorsutil.NewAggregate(errs)
-}
-
-// GeneratePassword can be used to generate random character string for 24 byte
-func GeneratePassword() (string, error) {
-	var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	password := make([]byte, 24)
-	for i := 0; i < 24; i++ {
-		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
-		if err != nil {
-			return "", err
-		}
-		password = append(password, letters[num.Int64()])
-	}
-
-	return string(password), nil
 }

--- a/transport/stunnel/server.go
+++ b/transport/stunnel/server.go
@@ -29,14 +29,14 @@ socket = r:TCP_NODELAY=1
 debug = 7
 sslVersion = TLSv1.3
 output=/dev/stdout
-{{ if .UseTLS }}
+{{ if .UsePSK }}
+ciphers = PSK
+PSKsecrets = /etc/stunnel/certs/key
+{{ else }}
 key = /etc/stunnel/certs/server.key
 cert = /etc/stunnel/certs/server.crt
 CAfile = /etc/stunnel/certs/ca.crt
 verify = 2
-{{ else }}
-ciphers = PSK
-PSKsecrets = /etc/stunnel/certs/key
 {{ end }}
 
 [transfer]
@@ -154,17 +154,17 @@ func (s *server) reconcileConfig(ctx context.Context, c ctrlclient.Client) error
 	type confFields struct {
 		AcceptPort  int32
 		ConnectPort int32
-		UseTLS      bool
+		UsePSK      bool
 	}
 	fields := confFields{
 		// acceptPort on which Stunnel service listens on, must connect with endpoint
 		AcceptPort: s.ListenPort(),
 		// connectPort in the container on which Transfer is listening on
 		ConnectPort: s.ConnectPort(),
-		UseTLS:      true,
+		UsePSK:      false,
 	}
 	if s.options.Credentials != nil && s.options.Credentials.Type == CredentialsTypePSK {
-		fields.UseTLS = false
+		fields.UsePSK = true
 	}
 	var stunnelConf bytes.Buffer
 	err = stunnelConfTemplate.Execute(&stunnelConf, fields)

--- a/transport/stunnel/server.go
+++ b/transport/stunnel/server.go
@@ -3,12 +3,11 @@ package stunnel
 import (
 	"bytes"
 	"context"
-	"strconv"
+	"fmt"
 	"text/template"
 
 	"github.com/backube/pvc-transfer/endpoint"
 	"github.com/backube/pvc-transfer/transport"
-	"github.com/backube/pvc-transfer/transport/tls/certs"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,20 +22,26 @@ const (
 	// this means that the tcp stack does not wait for receiving an ack
 	// before sending the next packet https://en.wikipedia.org/wiki/Nagle%27s_algorithm
 	// At scale setting/unsetting this option might drive different network characteristics
-	stunnelServerConfTemplate = `foreground = yes
+	stunnelServerConfTemplate = `foreground = no
 pid =
 socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 debug = 7
 sslVersion = TLSv1.3
-
-[transfer]
-accept = {{ $.acceptPort }}
-connect = {{ $.connectPort }}
+output=/dev/stdout
+{{ if .UseTLS }}
 key = /etc/stunnel/certs/server.key
 cert = /etc/stunnel/certs/server.crt
 CAfile = /etc/stunnel/certs/ca.crt
 verify = 2
+{{ else }}
+ciphers = PSK
+PSKsecrets = /etc/stunnel/certs/key
+{{ end }}
+
+[transfer]
+accept = {{ $.AcceptPort }}
+connect = {{ $.ConnectPort }}
 TIMEOUTclose = 0
 `
 	stunnelConnectPort = 8080
@@ -128,10 +133,7 @@ func (s *server) Type() transport.Type {
 }
 
 func (s *server) Credentials() types.NamespacedName {
-	return types.NamespacedName{
-		Name:      getResourceName(s.namespacedName, "certs", stunnelSecret),
-		Namespace: s.NamespacedName().Namespace,
-	}
+	return getCredentialsSecretRef(s, s.options.Credentials)
 }
 
 func (s *server) Hostname() string {
@@ -149,14 +151,23 @@ func (s *server) reconcileConfig(ctx context.Context, c ctrlclient.Client) error
 		return err
 	}
 
-	ports := map[string]string{
+	type confFields struct {
+		AcceptPort  int32
+		ConnectPort int32
+		UseTLS      bool
+	}
+	fields := confFields{
 		// acceptPort on which Stunnel service listens on, must connect with endpoint
-		"acceptPort": strconv.Itoa(int(s.ListenPort())),
+		AcceptPort: s.ListenPort(),
 		// connectPort in the container on which Transfer is listening on
-		"connectPort": strconv.Itoa(int(s.ConnectPort())),
+		ConnectPort: s.ConnectPort(),
+		UseTLS:      true,
+	}
+	if s.options.Credentials != nil && s.options.Credentials.Type == CredentialsTypePSK {
+		fields.UseTLS = false
 	}
 	var stunnelConf bytes.Buffer
-	err = stunnelConfTemplate.Execute(&stunnelConf, ports)
+	err = stunnelConfTemplate.Execute(&stunnelConf, fields)
 	if err != nil {
 		s.logger.Error(err, "unable to execute stunnel server config template")
 		return err
@@ -182,33 +193,37 @@ func (s *server) reconcileConfig(ctx context.Context, c ctrlclient.Client) error
 }
 
 func (s *server) reconcileSecret(ctx context.Context, c ctrlclient.Client) error {
-	secretValid, err := isSecretValid(ctx, c, s.logger, s.namespacedName, "certs")
-	if err != nil {
-		s.logger.Error(err, "error getting existing ssl certs from secret")
-		return err
-	}
-	if secretValid {
-		s.logger.V(4).Info("found secret with valid certs")
-		return nil
-	}
-
-	s.logger.Info("generating new certificate bundle")
-	crtBundle, err := certs.New()
-	if err != nil {
-		s.logger.Error(err, "error generating ssl certs for stunnel server")
-		return err
-	}
-	return reconcileCertificateSecrets(ctx, c, s.namespacedName, s.options, crtBundle)
+	return reconcileCredentialSecret(ctx, c, s.logger, s, s.options)
 }
 
 func (s *server) serverContainers() []corev1.Container {
+	stunnelScript := `/bin/stunnel /etc/stunnel/stunnel.conf
+	# terminate the transport when transfer isn't available
+	RETRY=0
+	while true; do
+		nc -z localhost %d
+		rc=$?
+		if [ $rc -ne 0 ]; then
+			RETRY=$((RETRY+1))
+		else
+			RETRY=0
+		fi
+		if [ $RETRY -gt 10 ]; then
+			exit 0
+		else
+			sleep 1
+		fi
+	done
+	`
+	stunnelScript = fmt.Sprintf(stunnelScript, s.ConnectPort())
 	return []corev1.Container{
 		{
 			Name:  Container,
 			Image: getImage(s.options),
 			Command: []string{
-				"/bin/stunnel",
-				"/etc/stunnel/stunnel.conf",
+				"/bin/bash",
+				"-c",
+				stunnelScript,
 			},
 			Ports: []corev1.ContainerPort{
 				{
@@ -245,26 +260,8 @@ func (s *server) serverVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: getResourceName(s.namespacedName, "certs", stunnelSecret),
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: getResourceName(s.namespacedName, "certs", stunnelSecret),
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "server.crt",
-							Path: "server.crt",
-						},
-						{
-							Key:  "server.key",
-							Path: "server.key",
-						},
-						{
-							Key:  "ca.crt",
-							Path: "ca.crt",
-						},
-					},
-				},
-			},
+			Name:         getResourceName(s.namespacedName, "certs", stunnelSecret),
+			VolumeSource: getCredentialsVolumeSource(s, s.options.Credentials, "server"),
 		},
 	}
 }

--- a/transport/stunnel/server_test.go
+++ b/transport/stunnel/server_test.go
@@ -182,7 +182,7 @@ func TestNewServer(t *testing.T) {
 			if !ok {
 				t.Error("unable to find stunnel config data in configmap")
 			}
-			if !strings.Contains(configData, "foreground = yes") {
+			if !strings.Contains(configData, "foreground = no") {
 				t.Error("configmap data does not contain the right data")
 			}
 

--- a/transport/stunnel/stunnel.go
+++ b/transport/stunnel/stunnel.go
@@ -24,6 +24,11 @@ const (
 )
 
 const (
+	CredentialsTypePSK transport.CredentialsType = "PSK"
+	CredentialsTypeTLS transport.CredentialsType = "TLS"
+)
+
+const (
 	TransportTypeStunnel transport.Type = "stunnel"
 	Container                           = "stunnel"
 )
@@ -44,12 +49,9 @@ func getResourceName(obj types.NamespacedName, component, prefix string) string 
 	return resourceName
 }
 
-func isSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger, key types.NamespacedName, component string) (bool, error) {
+func isTLSSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger, secretRef types.NamespacedName) (bool, error) {
 	secret := &corev1.Secret{}
-	err := c.Get(ctx, types.NamespacedName{
-		Namespace: key.Namespace,
-		Name:      getResourceName(key, component, stunnelSecret),
-	}, secret)
+	err := c.Get(ctx, secretRef, secret)
 	switch {
 	case k8serrors.IsNotFound(err):
 		return false, nil
@@ -59,46 +61,31 @@ func isSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger,
 
 	_, ok := secret.Data["client.key"]
 	if !ok {
-		logger.Info("secret data missing key client.key", "secret", types.NamespacedName{
-			Namespace: key.Namespace,
-			Name:      getResourceName(key, component, stunnelSecret),
-		})
+		logger.Info("secret data missing key client.key", "secret", secretRef)
 		return false, nil
 	}
 
 	_, ok = secret.Data["server.key"]
 	if !ok {
-		logger.Info("secret data missing key server.key", "secret", types.NamespacedName{
-			Namespace: key.Namespace,
-			Name:      getResourceName(key, component, stunnelSecret),
-		})
+		logger.Info("secret data missing key server.key", "secret", secretRef)
 		return false, nil
 	}
 
 	clientCrt, ok := secret.Data["client.crt"]
 	if !ok {
-		logger.Info("secret data missing key client.crt", "secret", types.NamespacedName{
-			Namespace: key.Namespace,
-			Name:      getResourceName(key, component, stunnelSecret),
-		})
+		logger.Info("secret data missing key client.crt", "secret", secretRef)
 		return false, nil
 	}
 
 	serverCrt, ok := secret.Data["server.crt"]
 	if !ok {
-		logger.Info("secret data missing key server.crt", "secret", types.NamespacedName{
-			Namespace: key.Namespace,
-			Name:      getResourceName(key, component, stunnelSecret),
-		})
+		logger.Info("secret data missing key server.crt", "secret", secretRef)
 		return false, nil
 	}
 
 	ca, ok := secret.Data["ca.crt"]
 	if !ok {
-		logger.Info("secret data missing key ca.crt", "secret", types.NamespacedName{
-			Namespace: key.Namespace,
-			Name:      getResourceName(key, component, stunnelSecret),
-		})
+		logger.Info("secret data missing key ca.crt", "secret", secretRef)
 		return false, nil
 	}
 
@@ -110,15 +97,94 @@ func isSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger,
 	return certs.VerifyCertificate(bytes.NewBuffer(ca), bytes.NewBuffer(serverCrt))
 }
 
-func reconcileCertificateSecrets(ctx context.Context,
+func isPSKSecretValid(ctx context.Context, c ctrlclient.Client, logger logr.Logger, secretRef types.NamespacedName) (bool, error) {
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, secretRef, secret)
+	switch {
+	case k8serrors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	_, ok := secret.Data["key"]
+	if !ok {
+		logger.Info("secret data missing PSK key", "secret", secretRef)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// reconcileCredentialSecret reconciles credential secrets for a stunnel transport
+func reconcileCredentialSecret(ctx context.Context,
 	c ctrlclient.Client,
-	key types.NamespacedName,
+	logger logr.Logger,
+	s transport.Transport,
+	o *transport.Options) error {
+	var err error
+	secretValid := false
+	credType := CredentialsTypeTLS
+	secretRef := types.NamespacedName{
+		Namespace: s.NamespacedName().Namespace,
+		Name:      getResourceName(s.NamespacedName(), "certs", stunnelSecret),
+	}
+	if o.Credentials != nil {
+		if o.Credentials.Type != "" {
+			credType = o.Credentials.Type
+		}
+		if o.Credentials.SecretRef.Name != "" {
+			secretRef = o.Credentials.SecretRef
+		}
+	}
+
+	switch credType {
+	case CredentialsTypePSK:
+		secretValid, err = isPSKSecretValid(ctx, c, logger, secretRef)
+		if err != nil {
+			logger.Error(err, "error getting existing PSK credentials from secret")
+			return err
+		}
+	case CredentialsTypeTLS:
+		secretValid, err = isTLSSecretValid(ctx, c, logger, secretRef)
+		if err != nil {
+			logger.Error(err, "error getting existing ssl certs from secret")
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported credentials type %s", credType)
+	}
+
+	if secretValid {
+		logger.V(4).Info("found secret with valid certs")
+		return nil
+	}
+
+	logger.Info("generating new certificate bundle")
+
+	switch credType {
+	case CredentialsTypeTLS:
+		crtBundle, err := certs.New()
+		if err != nil {
+			logger.Error(err, "error generating ssl certs for stunnel server")
+			return err
+		}
+		return reconcileTLSSecret(ctx, c, secretRef, o, crtBundle)
+	default:
+		return fmt.Errorf("cannot create credentials of type %s", credType)
+	}
+}
+
+// reconcileTLSSecret reconciles secret of TLS type
+func reconcileTLSSecret(ctx context.Context,
+	c ctrlclient.Client,
+	secretRef types.NamespacedName,
 	options *transport.Options,
 	crtBundle *certs.CertificateBundle) error {
 	crtBundleSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getResourceName(key, "certs", stunnelSecret),
-			Namespace: key.Namespace,
+			Namespace: secretRef.Namespace,
+			Name:      secretRef.Name,
 		},
 	}
 	_, err := controllerutil.CreateOrUpdate(ctx, c, crtBundleSecret, func() error {
@@ -140,6 +206,60 @@ func reconcileCertificateSecrets(ctx context.Context,
 	}
 
 	return err
+}
+
+func getCredentialsSecretRef(t transport.Transport, c *transport.Credentials) types.NamespacedName {
+	secretRef := types.NamespacedName{
+		Name:      getResourceName(t.NamespacedName(), "certs", stunnelSecret),
+		Namespace: t.NamespacedName().Namespace,
+	}
+	if c != nil {
+		if c.SecretRef.Name != "" {
+			secretRef = c.SecretRef
+		}
+	}
+	return secretRef
+}
+
+func getCredentialsVolumeSource(t transport.Transport, c *transport.Credentials, key string) corev1.VolumeSource {
+	tlsItems := []corev1.KeyToPath{
+		{
+			Key:  fmt.Sprintf("%s.crt", key),
+			Path: fmt.Sprintf("%s.crt", key),
+		},
+		{
+			Key:  fmt.Sprintf("%s.key", key),
+			Path: fmt.Sprintf("%s.key", key),
+		},
+		{
+			Key:  "ca.crt",
+			Path: "ca.crt",
+		},
+	}
+	pskItems := []corev1.KeyToPath{
+		{
+			Key:  "key",
+			Path: "key",
+		},
+	}
+	volumeSource := corev1.VolumeSource{
+		Secret: &corev1.SecretVolumeSource{
+			SecretName: getCredentialsSecretRef(t, c).Name,
+			Items:      tlsItems,
+		},
+	}
+	// when no existing credentials are provided, default to TLS
+	if c != nil {
+		switch c.Type {
+		case CredentialsTypeTLS:
+			volumeSource.Secret.Items = tlsItems
+			return volumeSource
+		case CredentialsTypePSK:
+			volumeSource.Secret.Items = pskItems
+			return volumeSource
+		}
+	}
+	return volumeSource
 }
 
 func markForCleanup(ctx context.Context, c ctrlclient.Client, objKey types.NamespacedName, key, value, component string) error {

--- a/transport/stunnel/stunnel_test.go
+++ b/transport/stunnel/stunnel_test.go
@@ -35,7 +35,7 @@ func Test_getExistingCert(t *testing.T) {
 			objects:        []ctrlclient.Object{},
 		},
 		{
-			name:           "test with invalid secret, key missing",
+			name:           "test with invalid TLS secret, key missing",
 			namespacedName: types.NamespacedName{Namespace: "bar", Name: "foo"},
 			labels:         map[string]string{"test": "me"},
 			wantErr:        false,
@@ -52,7 +52,7 @@ func Test_getExistingCert(t *testing.T) {
 			},
 		},
 		{
-			name:           "test with invalid secret, crt missing",
+			name:           "test with invalid TLS secret, crt missing",
 			namespacedName: types.NamespacedName{Namespace: "bar", Name: "foo"},
 			labels:         map[string]string{"test": "me"},
 			wantErr:        false,
@@ -69,7 +69,7 @@ func Test_getExistingCert(t *testing.T) {
 			},
 		},
 		{
-			name:           "test with secret missing ca.crt",
+			name:           "test with TLS secret missing ca.crt",
 			namespacedName: types.NamespacedName{Namespace: "bar", Name: "foo"},
 			labels:         map[string]string{"test": "me"},
 			wantErr:        true,
@@ -86,7 +86,7 @@ func Test_getExistingCert(t *testing.T) {
 			},
 		},
 		{
-			name:           "test with valid secret",
+			name:           "test with valid TLS secret",
 			namespacedName: types.NamespacedName{Namespace: "bar", Name: "foo"},
 			labels:         map[string]string{"test": "me"},
 			wantErr:        true,
@@ -116,8 +116,12 @@ func Test_getExistingCert(t *testing.T) {
 					Owners: testOwnerReferences(),
 				},
 			}
+			secretRef := types.NamespacedName{
+				Namespace: s.namespacedName.Namespace,
+				Name:      fmt.Sprintf("%s-%s-%s", stunnelSecret, "foo", s.namespacedName.Name),
+			}
 			ctx := context.WithValue(context.Background(), "test", tt.name)
-			found, err := isSecretValid(ctx, fakeClientWithObjects(tt.objects...), s.logger, s.namespacedName, "foo")
+			found, err := isTLSSecretValid(ctx, fakeClientWithObjects(tt.objects...), s.logger, secretRef)
 			if err != nil {
 				t.Error("found unexpected error", err)
 			}

--- a/transport/tls/certs/generate.go
+++ b/transport/tls/certs/generate.go
@@ -128,7 +128,7 @@ func VerifyCertificate(caCrt *bytes.Buffer, crt *bytes.Buffer) (bool, error) {
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM(caCrt.Bytes())
 	if !ok {
-		panic("failed to parse root certificate")
+		return false, fmt.Errorf("failed to parse root certificate")
 	}
 
 	block, _ := pem.Decode(crt.Bytes())

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -46,6 +46,8 @@ type Options struct {
 	Owners []metav1.OwnerReference
 	// Image allows for specifying the image used for running the transport containers
 	Image string
+	// Credentials allows specifying pre-existing transport credentials
+	*Credentials
 
 	// ProxyURL is used if the cluster is behind a proxy
 	ProxyURL string
@@ -54,5 +56,15 @@ type Options struct {
 	// ProxyPassword password for connecting to the proxy
 	ProxyPassword string
 }
+
+// Credentials are used by transports to encrypt data
+type Credentials struct {
+	// SecretRef ref to the secret holding credentials data
+	SecretRef types.NamespacedName
+	// Type type of credentials used
+	Type CredentialsType
+}
+
+type CredentialsType string
 
 type Type string


### PR DESCRIPTION
Signed-off-by: Pranav Gaikwad <pgaikwad@redhat.com>

**Describe what this PR does**
- Introduces new field in Transport Options to specify existing secrets:
   - Secrets may either contain TLS certs or a Pre-Shared Key
   - New secret is not created if existing secret is valid
- Updates rsync termination logic:
   - Rsync client will now send a file to a known location on the server to indicate transfer completion, server will exit when the file is present in destination. Previously, `_exit` message was read from server logs to exit
   - Transport container will exit when underlying Transfer is gone 
 

**Is there anything that requires special attention?**
~This PR does _NOT_ add support for creating a new PSK when existing is invalid. Creating PSK is not supported in go currently [1]. Users will need to provide their existing PSK in a secret. If not provided, library will default to creating new TLS certs instead. ~

Updated to create a 32 byte long PSK key. Stunnel requires key to be base64 encoded.  



**Related issues:**
[1] https://github.com/golang/go/issues/6379
